### PR TITLE
Add 2.2.x compatibility

### DIFF
--- a/Compatibility/CsrfAwareActionInterface.php
+++ b/Compatibility/CsrfAwareActionInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Iways\PayPalPlus\Compatibility;
+
+if (!\interface_exists('\\Magento\\Framework\\App\\CsrfAwareActionInterface')) {
+    interface CsrfAwareActionInterface {}
+} else {
+    interface CsrfAwareActionInterface extends \Magento\Framework\App\CsrfAwareActionInterface { }
+}

--- a/Controller/Webhooks/Twothree.php
+++ b/Controller/Webhooks/Twothree.php
@@ -14,7 +14,7 @@
 
 namespace Iways\PayPalPlus\Controller\Webhooks;
 
-use Magento\Framework\App\CsrfAwareActionInterface;
+use Iways\PayPalPlus\Compatibility\CsrfAwareActionInterface;
 use Magento\Framework\App\Request\InvalidRequestException;
 
 /**


### PR DESCRIPTION
Current implementation uses `\Magento\Framework\App\CsrfAwareActionInterface`, which is Magento 2.3 only.
To keep 2.2 compatibility, add Wrapper interface